### PR TITLE
Add aliases to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ defmodule MyApp.SampleCLI do
   option :verbose, count: true, aliases: [:v]
 
   command :hello do
+    aliases [:hi]
     description "Greets the user"
     long_description """
     Gives a nice a warm greeting to whoever would listen
@@ -68,6 +69,12 @@ Which can be used in the following way.
 
 ```
 sample_cli hello -vv world --from me
+```
+
+or using the command's alias:
+
+```
+sample_cli hi -vv world --from me
 ```
 
 The application usage will be shown if the parsing fails. The above example would show:

--- a/lib/ex_cli/command.ex
+++ b/lib/ex_cli/command.ex
@@ -5,6 +5,7 @@ defmodule ExCLI.Command do
     :name,
     :description,
     :long_description,
+    aliases: [],
     arguments: [],
     options: [],
     normalized_options: %{}
@@ -14,6 +15,7 @@ defmodule ExCLI.Command do
     name: atom,
     description: String.t,
     long_description: String.t,
+    aliases: [atom],
     arguments: [ExCLI.Argument.t],
     options: [ExCLI.Argument.t],
     normalized_options: map
@@ -31,5 +33,9 @@ defmodule ExCLI.Command do
     |> Map.put(:arguments, Enum.reverse(command.arguments))
     |> Map.put(:options, Enum.reverse(command.options))
     |> Map.put(:normalized_options, ExCLI.Util.generate_options(command.options, opts))
+  end
+
+  def match?(command, name) do
+    command.name == name || Enum.any?(command.aliases, &(&1 == name))
   end
 end

--- a/lib/ex_cli/dsl.ex
+++ b/lib/ex_cli/dsl.ex
@@ -29,6 +29,7 @@ defmodule ExCLI.DSL do
       count: true
 
     command :hello do
+      aliases [:hi]
       description "Greets the user"
       long_description \"""
       Gives a nice a warm greeting to whoever would listen
@@ -103,6 +104,22 @@ defmodule ExCLI.DSL do
         else
           @app Map.put(@app, key, value)
         end
+      end
+    end
+  end
+
+  @doc """
+  Adds aliases to the command.
+
+  Aliases can be used in place of the command's name on the command line.
+  """
+  @spec aliases([atom]) :: any
+  defmacro aliases(names) do
+    quote bind_quoted: [names: names] do
+      if @command do
+        @command Map.put(@command, :aliases, names)
+      else
+        raise "aliases can only be used inside a command"
       end
     end
   end

--- a/lib/ex_cli/parser.ex
+++ b/lib/ex_cli/parser.ex
@@ -1,7 +1,7 @@
 defmodule ExCLI.Parser do
   @moduledoc false
 
-  alias ExCLI.Argument
+  alias ExCLI.{Argument, Command}
 
 
   def parse(app, args) do
@@ -85,7 +85,7 @@ defmodule ExCLI.Parser do
   defp extract_command([{:arg, command} | rest]), do: {String.to_atom(command), rest}
 
   defp find_command(app, command_name) do
-    case Enum.find(app.commands, &(&1.name == command_name)) do
+    case Enum.find(app.commands, &(Command.match?(&1, command_name))) do
       nil -> {:error, :unknown_command, name: command_name}
       command -> {:ok, command}
     end

--- a/sample/cli.ex
+++ b/sample/cli.ex
@@ -10,6 +10,7 @@ defmodule MyApp.SampleCLI do
   option :verbose, help: "Increase the verbosity level", aliases: [:v], count: true
 
   command :hello do
+    aliases [:hi]
     description "Greets the user"
     long_description """
     Gives a nice a warm greeting to whoever would listen

--- a/test/ex_cli/dsl_test.exs
+++ b/test/ex_cli/dsl_test.exs
@@ -21,6 +21,7 @@ defmodule ExCLI.DSLTest do
     app = SampleCLI.__app__
     assert [command] = app.commands
     assert command.name == :hello
+    assert command.aliases == [:hi]
     assert [%Argument{name: name, help: help}] = command.options
     assert command.long_description == "Gives a nice a warm greeting to whoever would listen\n"
     assert name == :from

--- a/test/ex_cli_test.exs
+++ b/test/ex_cli_test.exs
@@ -5,12 +5,17 @@ defmodule ExCLITest do
 
   test "parse" do
     assert {:ok, :hello, %{name: "world"}} = ExCLI.parse(MyApp.SampleCLI, ["hello", "world"])
+    assert {:ok, :hello, %{name: "world"}} = ExCLI.parse(MyApp.SampleCLI, ["hi", "world"])
     assert {:ok, :hello, %{name: "world", verbose: 2}} = ExCLI.parse(MyApp.SampleCLI, ["-vv", "hello", "world"])
   end
 
   test "run" do
     assert capture_io(fn ->
       ExCLI.run(MyApp.SampleCLI, ["hello", "world"])
+    end) == "Hello world!\n"
+
+    assert capture_io(fn ->
+      ExCLI.run(MyApp.SampleCLI, ["hi", "world"])
     end) == "Hello world!\n"
 
     assert capture_io(fn ->


### PR DESCRIPTION
Allow a command to have one or more aliases to make the CLI more convenient to use.

Per the discussion in #5, this PR implements aliases for commands as opposed to some kind of fuzzy matching strategy..

Aliases are defined as follows:

```
command :hello do
  aliases [:hi]
  # ...
end
```

Implementation notes:
- `Parser` now delegates the matching of a command name to a command to `Command`; `Command.match/2` compares the provided name to the command's name and its aliases.

- I've tested this against one of my projects and it works great!

- I chose not to add the aliases to the usage output, as I felt that it would mess up the output too much.  Instead, the aliases can be shown in the detailed command help once that feature is implemented.

- I chose not to address the issue of potential collisions between an alias and another command (or an alias and another command's alias).  There is no collision detection done for command names currently, so I maintained that pattern.

Closes #5.