### PR TITLE
Fix formatting in command list

### DIFF
--- a/lib/ex_cli/formatter/text.ex
+++ b/lib/ex_cli/formatter/text.ex
@@ -27,25 +27,32 @@ defmodule ExCLI.Formatter.Text do
 
   def format_commands(commands, opts \\ []) do
     opts = make_opts(opts)
-    space_size = commands_space_size(commands)
+    column_width = command_name_column_width(commands)
     commands
-    |> Enum.map(&format_command(&1, space_size: space_size))
+    |> Enum.map(&format_command(&1, column_width: column_width))
     |> Enum.join("#{opts[:newline]}" <> String.duplicate(opts[:pad_with], 3))
   end
 
   def format_command(command, opts \\ []) do
     name = Atom.to_string(command.name)
+    name_width = command_name_width(command)
+    column_width = Keyword.get(opts, :column_width, name_width)
+    spaces = column_width - name_width + 3
     if description = command.description do
-      name <> String.duplicate(" ", Keyword.get(opts, :space_size, 2)) <> description
+      name <> String.duplicate(" ", spaces) <> description
     else
       name
     end
   end
 
-  defp commands_space_size([]), do: 0
-  defp commands_space_size(commands) do
-    command_lengths = commands |> Enum.map(&(&1.name |> to_string |> byte_size))
-    Enum.max(command_lengths) - Enum.min(command_lengths) + 3
+  defp command_name_column_width([]), do: 0
+  defp command_name_column_width(commands) do
+    command_lengths = commands |> Enum.map(&command_name_width/1)
+    Enum.max(command_lengths)
+  end
+
+  defp command_name_width(command) do
+    command.name |> to_string |> byte_size
   end
 
   defp format_argument(%Argument{type: :boolean}), do: nil

--- a/sample/complex_cli.ex
+++ b/sample/complex_cli.ex
@@ -32,6 +32,12 @@ defmodule MyApp.ComplexCLI do
     end
   end
 
+  command :speak do
+    run _context do
+      IO.puts "I can speak"
+    end
+  end
+
   command :talk do
     description "Talks to the user"
     run _context do

--- a/sample/complex_cli.ex
+++ b/sample/complex_cli.ex
@@ -32,9 +32,10 @@ defmodule MyApp.ComplexCLI do
     end
   end
 
-  command :speak do
+  command :talk do
+    description "Talks to the user"
     run _context do
-      IO.puts "I can speak"
+      IO.puts "I can talk"
     end
   end
 end

--- a/test/ex_cli/formatter/text_test.exs
+++ b/test/ex_cli/formatter/text_test.exs
@@ -7,6 +7,7 @@ defmodule ExCLI.Formatter.TextTest do
 
   Commands
      talk    Talks to the user
+     speak
      hello   Greets the user
   """
 
@@ -20,6 +21,8 @@ defmodule ExCLI.Formatter.TextTest do
 
   \t\t\ttalk    Talks to the user
 
+  \t\t\tspeak
+
   \t\t\thello   Greets the user
   """
 
@@ -32,6 +35,6 @@ defmodule ExCLI.Formatter.TextTest do
   end
 
   defp expected(output) do
-    output |> String.trim_trailing("\n")
+    output |> String.replace_trailing("\n", "")
   end
 end

--- a/test/ex_cli/formatter/text_test.exs
+++ b/test/ex_cli/formatter/text_test.exs
@@ -1,14 +1,37 @@
 defmodule ExCLI.Formatter.TextTest do
   use ExUnit.Case
 
-  @sample_cli_expected_usage "usage: mycli [--verbose] <command> [<args>]\n\nCommands\n   hello   Greets the user"
-  @sample_cli_expected_mix_usage "usage: mycli [--verbose] <command> [<args>]\n\n\nCommands\n\n\t\t\thello   Greets the user"
+  @complex_cli_usage """
+  usage: mycli [-v] [--debug] [--base-directory=<directory>] [--log-file=<file>]
+               <command> [<args>]
+
+  Commands
+     talk    Talks to the user
+     hello   Greets the user
+  """
+
+  @complex_cli_mix_usage """
+  usage: mycli [-v] [--debug] [--base-directory=<directory>] [--log-file=<file>]
+
+  \t\t\t\t\t\t\t\t\t\t\t\t\t<command> [<args>]
+
+
+  Commands
+
+  \t\t\ttalk    Talks to the user
+
+  \t\t\thello   Greets the user
+  """
 
   test "format" do
-    assert ExCLI.Formatter.Text.format(MyApp.SampleCLI.__app__) == @sample_cli_expected_usage
+    assert ExCLI.Formatter.Text.format(MyApp.ComplexCLI.__app__) == expected(@complex_cli_usage)
   end
 
   test "format for mix" do
-    assert ExCLI.Formatter.Text.format(MyApp.SampleCLI.__app__, mix: true) == @sample_cli_expected_mix_usage
+    assert ExCLI.Formatter.Text.format(MyApp.ComplexCLI.__app__, mix: true) == expected(@complex_cli_mix_usage)
+  end
+
+  defp expected(output) do
+    output |> String.trim_trailing("\n")
   end
 end


### PR DESCRIPTION
In my application, I noticed that the columns were not aligned correctly in the usage output:

```
usage: invoice [--file=<file>] <command> [<args>]

Commands
   status       Show an invoice status report
   list       List invoices
   payment       Records a payment
   generate       Generates an invoice (eventually)
   record       Records an invoice
```

This PR fixes the column alignment code, so the output now looks like this:

```
usage: invoice [--file=<file>] <command> [<args>]

Commands
   status     Show an invoice status report
   list       List invoices
   payment    Records a payment
   generate   Generates an invoice (eventually)
   record     Records an invoice
```

Notes:
- In order to be able to test this, I switched the formatter test to use `ComplexCLI` instead of `SampleCLI` since it has more than one command.  I also added a new `talk` command so there would be a command that has a different width than the `hello` command.  I kept the `speak` command in place without a description so that the "no description" path would be covered by the tests (it wasn't otherwise).

- I changed the formatter test to use a heredoc for the expected output to make it more readable.  However, this now resulted in an extra newline at the end of the output.  I added a little helper function to the test to strip that back out so we don't get an extra blank line at the end of the output.  I had to use `String.replace_trailing/3` instead of my original `String.trim_trailing/2` to remain compatible with Elixir 1.2.x.

- The decreased coverage is because there's a new command in `ComplexCLI` that never gets executed.  I'm not sure what to do about that.