### PR TITLE
Adding support for defaults

### DIFF
--- a/lib/ex_cli/app.ex
+++ b/lib/ex_cli/app.ex
@@ -37,4 +37,9 @@ defmodule ExCLI.App do
     |> Map.put(:commands, Enum.map(app.commands, &ExCLI.Command.finalize(&1, app.opts)))
     |> Map.put(:normalized_options, ExCLI.Util.generate_options(app.options, app.opts))
   end
+
+  @doc false
+  def has_default_command?(app) do
+    Enum.any?(app.commands, &(is_nil(&1.name)))  
+  end
 end

--- a/lib/ex_cli/command.ex
+++ b/lib/ex_cli/command.ex
@@ -36,6 +36,7 @@ defmodule ExCLI.Command do
   end
 
   def match?(command, name) do
+    # note that this will also match the nil (i.e. default) command
     command.name == name || Enum.any?(command.aliases, &(&1 == name))
   end
 end

--- a/lib/ex_cli/dsl.ex
+++ b/lib/ex_cli/dsl.ex
@@ -234,6 +234,19 @@ defmodule ExCLI.DSL do
     end
   end
 
+  @spec default_command(Keyword.t) :: any
+  defmacro default_command(do: block) do
+    quote do
+      @command %ExCLI.Command{}
+      if Enum.any?(@app.commands, &(&1.name == nil)) do 
+        raise "Cannot have more than one default command."
+      end
+      unquote(block)
+      @app Map.put(@app, :commands, [@command | @app.commands])
+      @command nil
+    end
+  end
+
   @doc false
   def __define_mix_task__(mod, app, name) do
     app = Macro.escape(app)

--- a/lib/ex_cli/dsl.ex
+++ b/lib/ex_cli/dsl.ex
@@ -238,7 +238,7 @@ defmodule ExCLI.DSL do
   defmacro default_command(do: block) do
     quote do
       @command %ExCLI.Command{}
-      if Enum.any?(@app.commands, &(&1.name == nil)) do 
+      if ExCLI.App.has_default_command?(@app) do
         raise "Cannot have more than one default command."
       end
       unquote(block)

--- a/lib/ex_cli/formatter/text.ex
+++ b/lib/ex_cli/formatter/text.ex
@@ -5,7 +5,8 @@ defmodule ExCLI.Formatter.Text do
 
   def format(app, opts \\ []) do
     opts = opts |> Keyword.put_new(:name, app.name) |> make_app_opts()
-    arguments = format_options(app.options) ++ ["<command>", "[<args>]"]
+    command = if ExCLI.App.has_default_command?(app), do: "[<command>]", else: "<command>"
+    arguments = format_options(app.options) ++ [command, "[<args>]"]
     formatted_arguments = Util.pretty_join(arguments, opts)
 
     opts[:banner]
@@ -34,7 +35,7 @@ defmodule ExCLI.Formatter.Text do
   end
 
   def format_command(command, opts \\ []) do
-    name = Atom.to_string(command.name)
+    name = Atom.to_string(command.name || :DEFAULT)
     name_width = command_name_width(command)
     column_width = Keyword.get(opts, :column_width, name_width)
     spaces = column_width - name_width + 3
@@ -52,7 +53,7 @@ defmodule ExCLI.Formatter.Text do
   end
 
   defp command_name_width(command) do
-    command.name |> to_string |> byte_size
+    (command.name || :DEFAULT) |> to_string |> byte_size
   end
 
   defp format_argument(%Argument{type: :boolean}), do: nil

--- a/lib/ex_cli/parser.ex
+++ b/lib/ex_cli/parser.ex
@@ -81,12 +81,17 @@ defmodule ExCLI.Parser do
     end
   end
 
-  defp extract_command([]), do: {:error, :no_command, []}
+  defp extract_command([]), do: {nil, []}
   defp extract_command([{:arg, command} | rest]), do: {String.to_atom(command), rest}
 
   defp find_command(app, command_name) do
     case Enum.find(app.commands, &(Command.match?(&1, command_name))) do
-      nil -> {:error, :unknown_command, name: command_name}
+      nil ->
+        if command_name == nil do
+          {:error, :no_command, []}
+        else
+          {:error, :unknown_command, name: command_name}
+        end
       command -> {:ok, command}
     end
   end

--- a/sample/cli_with_default.ex
+++ b/sample/cli_with_default.ex
@@ -1,0 +1,18 @@
+defmodule MyApp.SampleCLIWithDefaultCommand do
+  use ExCLI.DSL, mix_task: :with_default
+
+  name "mycli"
+  description "My CLI"
+  long_description """
+  This is my long description
+  """
+
+  option :verbose, help: "Increase the verbosity level", aliases: [:v], count: true
+
+  default_command do
+    run _ do
+      IO.puts("Hello world with defaults!")
+    end
+  end
+end
+

--- a/sample/cli_with_default.ex
+++ b/sample/cli_with_default.ex
@@ -10,6 +10,11 @@ defmodule MyApp.SampleCLIWithDefaultCommand do
   option :verbose, help: "Increase the verbosity level", aliases: [:v], count: true
 
   default_command do
+    aliases [:hi]
+    description "Greets the user"
+    long_description """
+    Gives a nice a warm greeting to whoever would listen
+    """
     run _ do
       IO.puts("Hello world with defaults!")
     end

--- a/test/ex_cli_test.exs
+++ b/test/ex_cli_test.exs
@@ -19,6 +19,10 @@ defmodule ExCLITest do
     end) == "Hello world!\n"
 
     assert capture_io(fn ->
+      ExCLI.run(MyApp.SampleCLIWithDefaultCommand, [])
+    end) == "Hello world with defaults!\n"
+
+    assert capture_io(fn ->
       ExCLI.run(MyApp.SampleCLI, ["-vv", "hello", "world", "--from", "Daniel"])
     end) == "Running hello command.\nDaniel says: Hello world!\n"
   end


### PR DESCRIPTION
I had some free time on my hands, so I decided to play around with your library! This is a RFC to add support for defaults. The syntax would look like this:

```
default_command do
   # stuff that you put in any command
end
```

If you have a default command, the help will look like this:

![help](https://user-images.githubusercontent.com/828897/39892011-203f34f0-5497-11e8-8cf1-45ab1e930b87.png)

Note that the nil command name is replaced with `DEFAULT` and `<command>` turns into `[<command>]`, as it's now optional.

Let me know what you think!